### PR TITLE
Updated maven build settings

### DIFF
--- a/docking-frames-common/pom.xml
+++ b/docking-frames-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.dockingframes</groupId>
 		<artifactId>docking-frames-base</artifactId>
-		<version>1.1.1-SNAPSHOT</version>
+		<version>1.1.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>docking-frames-common</artifactId>

--- a/docking-frames-core/pom.xml
+++ b/docking-frames-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.dockingframes</groupId>
 		<artifactId>docking-frames-base</artifactId>
-		<version>1.1.1-SNAPSHOT</version>
+		<version>1.1.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>docking-frames-core</artifactId>

--- a/docking-frames-ext-glass/pom.xml
+++ b/docking-frames-ext-glass/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.dockingframes</groupId>
 		<artifactId>docking-frames-base</artifactId>
-		<version>1.1.1-SNAPSHOT</version>
+		<version>1.1.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>docking-frames-ext-glass</artifactId>

--- a/docking-frames-ext-toolbar-common/pom.xml
+++ b/docking-frames-ext-toolbar-common/pom.xml
@@ -2,9 +2,13 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>bibliothek</groupId>
+  <parent>
+    <groupId>org.dockingframes</groupId>
+    <artifactId>docking-frames-base</artifactId>
+    <version>1.1.2-SNAPSHOT</version>
+  </parent>
+
   <artifactId>docking-frames-ext-toolbar-common</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>docking-frames-ext-toolbar-common</name>
@@ -40,7 +44,7 @@
     <dependency>
       <groupId>org.dockingframes</groupId>
       <artifactId>docking-frames-common</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/docking-frames-ext-toolbar-tutorial/pom.xml
+++ b/docking-frames-ext-toolbar-tutorial/pom.xml
@@ -2,9 +2,13 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>bibliothek</groupId>
+  <parent>
+    <groupId>org.dockingframes</groupId>
+    <artifactId>docking-frames-base</artifactId>
+    <version>1.1.2-SNAPSHOT</version>
+  </parent>
+
   <artifactId>tutorial-toolbar</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>docking-frames-ext-toolbar-tutorial</name>

--- a/docking-frames-ext-toolbar/pom.xml
+++ b/docking-frames-ext-toolbar/pom.xml
@@ -2,9 +2,13 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>bibliothek</groupId>
+  <parent>
+    <groupId>org.dockingframes</groupId>
+    <artifactId>docking-frames-base</artifactId>
+    <version>1.1.2-SNAPSHOT</version>
+  </parent>
+
   <artifactId>docking-frames-ext-toolbar</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>docking-frames-ext-toolbar</name>
@@ -40,7 +44,7 @@
     <dependency>
       <groupId>org.dockingframes</groupId>
       <artifactId>docking-frames-common</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,13 +11,15 @@
 
 	<groupId>org.dockingframes</groupId>
 	<artifactId>docking-frames-base</artifactId>
-	<version>1.1.1-SNAPSHOT</version>
+	<version>1.1.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>
 
 		<module>docking-frames-core</module>
 		<module>docking-frames-common</module>
+		<module>docking-frames-ext-toolbar</module>
+		<module>docking-frames-ext-toolbar-common</module>
 
 		<!-- TODO ask Steffen Kux, software@kuxfamily.de to publish glasslib.jar on
 			maven -->


### PR DESCRIPTION
Updated POMs to use 1.1.2-SNAPSHOT as version number in preparation of nightly deployment to Sonatype. Please integrate.
