### PR TITLE
Resource Manager writes invalid version for reading

### DIFF
--- a/docking-frames-common/src/bibliothek/gui/dock/support/util/ApplicationResourceManager.java
+++ b/docking-frames-common/src/bibliothek/gui/dock/support/util/ApplicationResourceManager.java
@@ -101,7 +101,7 @@ public class ApplicationResourceManager {
      */
     public void writeStream( DataOutputStream out ) throws IOException{
         // version
-        Version.write( out, Version.VERSION_1_0_4 );
+        Version.write( out, Version.CURRENT );
         
         // number of elements
         out.writeInt( resources.size() );


### PR DESCRIPTION
Bug: Resource Manager always writes the first version, but reads a file with the last version (method version.checkCurrent()).
