### PR TITLE
Generate OSGi manifest using maven bundle plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,21 @@
 					</archive>
 				</configuration>
 			</plugin>
-
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>2.3.7</version>
+				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>bundle-manifest</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 
 	</build>


### PR DESCRIPTION
DockingFrames cannot be used in an OSGi framework. This patch configure projects to automatically generate OSGi manifest.