### PR TITLE
Fix missing manifest in output jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,7 @@
 							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
 							<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
 						</manifest>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 					</archive>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Hi,

Sorry I forget to add this instruction in order to include the generated manifest into each jar files.

Thanks