### PR TITLE
squid:S2162 - equals methods should be symmetric and work for subclasses

### DIFF
--- a/docking-frames-common/src/bibliothek/gui/dock/common/mode/station/CSplitDockStationHandle.java
+++ b/docking-frames-common/src/bibliothek/gui/dock/common/mode/station/CSplitDockStationHandle.java
@@ -258,9 +258,15 @@ public class CSplitDockStationHandle{
 		
 		@Override
 		public boolean equals( Object obj ){
-			if( obj == this )
+			if( obj == this ) {
 				return true;
-			if( obj instanceof ModeAreaListenerWrapper ){
+			}
+
+			if (obj == null) {
+				return false;
+			}
+
+			if( this.getClass() == obj.getClass() ){
 				ModeAreaListenerWrapper other = (ModeAreaListenerWrapper)obj;
 				return other.area.equals( area ) && other.listener.equals( listener );
 			}

--- a/docking-frames-core/src/bibliothek/extension/gui/dock/preference/PreferenceOperation.java
+++ b/docking-frames-core/src/bibliothek/extension/gui/dock/preference/PreferenceOperation.java
@@ -109,7 +109,15 @@ public class PreferenceOperation {
 
     @Override
     public boolean equals( Object obj ) {
-        if( obj instanceof PreferenceOperation ){
+		if (obj == this) {
+			return true;
+		}
+
+		if (obj == null) {
+			return false;
+		}
+
+        if( obj.getClass() == this.getClass() ){
             return key.equals( ((PreferenceOperation)obj).key );
         }
         

--- a/docking-frames-core/src/bibliothek/gui/dock/action/ActionType.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/action/ActionType.java
@@ -104,13 +104,19 @@ public class ActionType<D extends DockAction> {
 
 	@Override
 	public boolean equals( Object obj ){
-		if (this == obj)
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		}
+
+		if (obj == null) {
 			return false;
-		if( !(obj instanceof ActionType))
-			return false;
+		}
+
+		if( this.getClass() == obj.getClass() ) {
+			return ((ActionType<?>)obj).id.equals( id );
+		}
+
+		return false;
 		
-		return ((ActionType<?>)obj).id.equals( id );
 	}
 }

--- a/docking-frames-core/src/bibliothek/gui/dock/action/LocationHint.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/action/LocationHint.java
@@ -171,20 +171,7 @@ public class LocationHint {
 		public Hint( String id ){
 			super( id );
 		}
-		
-		@Override
-		public boolean equals( Object obj ){
-			return (obj instanceof Hint) && super.equals( obj );
-		}
-		
-		/**
-		 * Compares this hint with <code>other</code>.
-		 * @param other the other hint
-		 * @return <code>true</code> if they have the same id.
-		 */
-		public boolean equals( Hint other ){
-			return other.getId().equals(  getId() );
-		}
+
 	}
 	
 	/**
@@ -199,20 +186,7 @@ public class LocationHint {
 		public Origin( String id ){
 			super( id );
 		}
-		
-		@Override
-		public boolean equals( Object obj ){
-			return (obj instanceof Origin) && super.equals( obj );
-		}
-		
-		/**
-		 * Compares this origin with another origin.
-		 * @param other the other origin
-		 * @return <code>true</code> if they have the same id
-		 */
-		public boolean equals( Origin other ){
-			return other.getId().equals(  getId() );
-		}
+
 	}
 	
 	/**

--- a/docking-frames-core/src/bibliothek/gui/dock/action/view/ViewTarget.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/action/view/ViewTarget.java
@@ -89,13 +89,19 @@ public class ViewTarget<A> {
 
 	@Override
 	public boolean equals( Object obj ){
-		if (this == obj)
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		}
+
+		if (obj == null) {
 			return false;
-		if( !(obj instanceof ViewTarget))
-			return false;
-		
-		return ((ViewTarget<?>)obj).id.equals( id );
+		}
+
+		if( this.getClass() == obj.getClass()) {
+			return ((ViewTarget<?>)obj).id.equals( id );
+		}
+
+		return false;
+
 	}
 }

--- a/docking-frames-core/src/bibliothek/gui/dock/layout/AbstractDockableProperty.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/layout/AbstractDockableProperty.java
@@ -79,18 +79,24 @@ public abstract class AbstractDockableProperty implements DockableProperty {
 
 	@Override
 	public boolean equals( Object obj ){
-		if( this == obj )
+		if( this == obj ) {
 			return true;
-		if( obj == null )
+		}
+
+		if( obj == null ) {
 			return false;
-		if( !(obj instanceof AbstractDockableProperty) )
-			return false;
-		AbstractDockableProperty other = (AbstractDockableProperty)obj;
-		if( successor == null ){
-			if( other.successor != null )
+		}
+
+		if( this.getClass() == obj.getClass() ) {
+			AbstractDockableProperty other = (AbstractDockableProperty)obj;
+			if( successor == null ){
+				if( other.successor != null )
+					return false;
+			}else if( !successor.equals( other.successor ) )
 				return false;
-		}else if( !successor.equals( other.successor ) )
-			return false;
-		return true;
-	}   
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/docking-frames-core/src/bibliothek/gui/dock/station/split/SplitDockPathProperty.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/station/split/SplitDockPathProperty.java
@@ -360,19 +360,24 @@ public class SplitDockPathProperty extends AbstractDockableProperty implements I
 
 	@Override
 	public boolean equals( Object obj ){
-		if( this == obj )
-			return true;
-		if( !super.equals( obj ) )
-			return false;
-		if( !(obj instanceof SplitDockPathProperty) )
-			return false;
-		SplitDockPathProperty other = (SplitDockPathProperty)obj;
-		if( nodes == null ){
-			if( other.nodes != null )
-				return false;
-		}else if( !nodes.equals( other.nodes ) )
-			return false;
-		return true;
+		if( this == obj ) {
+            return true;
+        }
+
+		if( !super.equals( obj ) ) {
+            return false;
+        }
+
+		if( obj.getClass() == this.getClass() ) {
+            SplitDockPathProperty other = (SplitDockPathProperty)obj;
+            if( nodes == null ){
+                if( other.nodes != null )
+                    return false;
+            }else if( !nodes.equals( other.nodes ) )
+                return false;
+            return true;
+        }
+        return false;
 	}
 
 
@@ -445,22 +450,27 @@ public class SplitDockPathProperty extends AbstractDockableProperty implements I
 
 		@Override
 		public boolean equals( Object obj ){
-			if( this == obj )
-				return true;
-			if( obj == null )
-				return false;
-			if( !(obj instanceof Node) )
-				return false;
-			Node other = (Node)obj;
-			if( location == null ){
-				if( other.location != null )
-					return false;
-			}else if( !location.equals( other.location ) )
-				return false;
-			if( Double.doubleToLongBits( size ) != Double
-					.doubleToLongBits( other.size ) )
-				return false;
-			return true;
+			if( this == obj ) {
+                return true;
+            }
+
+			if( obj == null ) {
+                return false;
+            }
+
+			if( this.getClass() == obj.getClass() ) {
+                Node other = (Node)obj;
+                if( location == null ){
+                    if( other.location != null )
+                        return false;
+                }else if( !location.equals( other.location ) )
+                    return false;
+                if( Double.doubleToLongBits( size ) != Double
+                        .doubleToLongBits( other.size ) )
+                    return false;
+                return true;
+            }
+            return false;
 		}
     }
 }

--- a/docking-frames-core/src/bibliothek/gui/dock/station/stack/StackDockProperty.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/station/stack/StackDockProperty.java
@@ -200,15 +200,24 @@ public class StackDockProperty extends AbstractDockableProperty {
 
 	@Override
 	public boolean equals( Object obj ){
-		if( this == obj )
-			return true;
-		if( !super.equals( obj ) )
-			return false;
-		if( !(obj instanceof StackDockProperty) )
-			return false;
-		StackDockProperty other = (StackDockProperty)obj;
-		if( index != other.index )
-			return false;
-		return true;
+        if( this == obj ) {
+            return true;
+        }
+
+        if( obj == null ) {
+            return false;
+        }
+
+        if( !super.equals( obj ) ) {
+            return false;
+        }
+
+		if( obj.getClass() == this.getClass() ) {
+            StackDockProperty other = (StackDockProperty)obj;
+            if( index != other.index )
+                return false;
+            return true;
+        }
+        return false;
 	}
 }

--- a/docking-frames-core/src/bibliothek/gui/dock/station/stack/action/DockActionDistributor.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/station/stack/action/DockActionDistributor.java
@@ -68,7 +68,19 @@ public interface DockActionDistributor {
 		
 		@Override
 		public boolean equals( Object obj ){
-			return obj instanceof Target && ((Target)obj).id.equals( id );
+			if (obj == this) {
+				return true;
+			}
+
+			if (obj == null) {
+				return false;
+			}
+
+			if (obj.getClass() == this.getClass()) {
+				return ((Target) obj).id.equals(id);
+			}
+
+			return false;
 		}
 	};
 

--- a/docking-frames-core/src/bibliothek/gui/dock/title/DockTitleVersion.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/title/DockTitleVersion.java
@@ -257,7 +257,19 @@ public class DockTitleVersion implements DockTitleFactory{
     
     @Override
     public boolean equals( Object obj ) {
-        return (obj instanceof DockTitleVersion) && ((DockTitleVersion)obj).id.equals( id );
+		if (obj == this) {
+			return true;
+		}
+
+		if (obj == null) {
+			return false;
+		}
+
+		if (obj.getClass() == this.getClass()) {
+			return (((DockTitleVersion)obj).id.equals( id ));
+		}
+
+		return false;
     }
     
     /**

--- a/docking-frames-core/src/bibliothek/util/container/Quartuple.java
+++ b/docking-frames-core/src/bibliothek/util/container/Quartuple.java
@@ -66,10 +66,19 @@ public class Quartuple<A,B,C,D> extends Triple<A,B,C>{
     @SuppressWarnings("unchecked")
 	@Override
 	public boolean equals( Object o ){
-		if( o instanceof Quartuple ){
+		if (this == o) {
+			return true;
+		}
+
+		if (o == null) {
+			return false;
+		}
+
+		if (this.getClass() == o.getClass()) {
 			Quartuple s = (Quartuple)o;
 			return super.equals( o ) && ( (s.d == null && d == null) || (s.d != null && s.d.equals( d )));
 		}
+
 		return false;
 	}
 	

--- a/docking-frames-core/src/bibliothek/util/container/Triple.java
+++ b/docking-frames-core/src/bibliothek/util/container/Triple.java
@@ -65,10 +65,19 @@ public class Triple<A, B, C> extends Tuple<A, B>{
     @SuppressWarnings("unchecked")
 	@Override
 	public boolean equals( Object o ){
-		if( o instanceof Triple ){
+		if (o == this) {
+			return true;
+		}
+
+		if (o == null) {
+			return false;
+		}
+
+		if (o.getClass() == this.getClass()){
 			Triple s = (Triple)o;
 			return super.equals( o ) && ( (s.c == null && c == null) || (s.c != null && s.c.equals( c )));
 		}
+
 		return false;
 	}
 	


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2162 - "equals" methods should be symmetric and work for subclasses

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162

Please let me know if you have any questions.

M-Ezzat