### PR TITLE
squid:S1941 - Variables should not be declared before they are relevant

### DIFF
--- a/docking-frames-common/src/bibliothek/gui/dock/common/CControl.java
+++ b/docking-frames-common/src/bibliothek/gui/dock/common/CControl.java
@@ -578,15 +578,15 @@ public class CControl {
         frontend.getController().getFocusController().addVetoListener( new ControlVetoFocusListener( this, listenerCollection.getVetoFocusListener() ) );
         frontend.getController().getFocusController().setStrategy( new DefaultFocusStrategy( frontend.getController() ){
         	public Component getFocusComponent( FocusStrategyRequest request ){
-        		Component mouseClicked = request.getMouseClicked();
-        		Dockable dockable = request.getDockable();
-        		
+
+                Component mouseClicked = request.getMouseClicked();
 				if( mouseClicked != null ){
 					if( (mouseClicked.isFocusable() && !excluded( mouseClicked, request )) || focusable( mouseClicked, request )){
 						return mouseClicked;
 					}
 				}
-				
+
+                Dockable dockable = request.getDockable();
 				if( dockable instanceof CommonDockable ){
 					Component result = ((CommonDockable)dockable).getDockable().getFocusComponent();
 					if( result != null ){
@@ -1936,20 +1936,18 @@ public class CControl {
      * or is not registered (see {@link #addMultipleDockableFactory(String, MultipleCDockableFactory)}).
      */
     public <M extends MultipleCDockable> M addDockable( M dockable) {
-        Set<String> ids = new HashSet<String>();
 
-        String factoryId;
         MultipleCDockableFactory<?, ?> factory = dockable.getFactory();
         if( factory == null ){
         	throw new IllegalArgumentException( "factory of dockable must not be null" );
         }
-        
-        factoryId = access.getFactoryId( dockable.getFactory() );
+
+        String factoryId = access.getFactoryId( dockable.getFactory() );
         if( factoryId == null ){
         	throw new IllegalStateException( "the factory for a MultipleCDockable is not registered: " + dockable.getFactory() );
-        }        	
-        
+        }
 
+        Set<String> ids = new HashSet<String>();
         for( MultipleCDockable multi : register.getMultipleDockables() ){
             if( factoryId.equals( access.getFactoryId( multi.getFactory() ))){
                 ids.add( accesses.get( multi ).getUniqueId() );
@@ -2840,8 +2838,7 @@ public class CControl {
             DockRegister register = frontend.getController().getRegister();
             register.setStalled( true );
             try{
-            	CLocation location = dockable.getAutoBaseLocation( true );
-            	
+
             	CDockableAccess access = access( dockable );
             	if( access != null ){
             		access.internalLocation( true );
@@ -2853,7 +2850,8 @@ public class CControl {
                         throw new IllegalStateException( "A dockable that wants to be on a CWorkingArea can't be made visible unless the CWorkingArea is visible." );
                     }
                 }
-                
+
+                CLocation location = dockable.getAutoBaseLocation( true );
                 if( location == null ){
                 	dockable.setExtendedMode( findInitialMode( dockable ) );
                 }

--- a/docking-frames-common/src/bibliothek/gui/dock/common/group/StackGroupMovement.java
+++ b/docking-frames-common/src/bibliothek/gui/dock/common/group/StackGroupMovement.java
@@ -58,8 +58,6 @@ public class StackGroupMovement implements CGroupMovement{
 	}
 	
 	public void apply( CGroupBehaviorCallback callback ){
-		// find location of dockable in respect to the other items
-		int baseIndex = dockParent.indexOf( dockable );
 		Dockable[] children = new Dockable[ dockParent.getDockableCount() ];
 		for( int i = 0; i < children.length; i++ ){
 			children[i] = dockParent.getDockable( i );
@@ -87,7 +85,9 @@ public class StackGroupMovement implements CGroupMovement{
 		if( !oneMissing ){
 			return;
 		}
-		
+
+		// find location of dockable in respect to the other items
+		int baseIndex = dockParent.indexOf( dockable );
 		int missing = 0;
 		
 		// move all the items that were before dockable

--- a/docking-frames-common/src/bibliothek/gui/dock/common/intern/station/CommonDockStationFactory.java
+++ b/docking-frames-common/src/bibliothek/gui/dock/common/intern/station/CommonDockStationFactory.java
@@ -322,13 +322,12 @@ public class CommonDockStationFactory implements DockFactory<CommonDockStation<?
 			id = xid.getString();
 		}
 		
-		boolean root = element.getElement( "root" ).getBoolean();
-		
 		XElement xcontent = element.getElement( "content" );
 		if( xcontent == null ){
 			throw new XException( "missing content element" );
 		}
-		
+
+		boolean root = element.getElement( "root" ).getBoolean();
 		String factoryId = xcontent.getString( "delegate" );
 		DockFactory<DockElement, ?, Object> factory = (DockFactory<DockElement, ?, Object>)control.intern().getDockFactory( factoryId );
 		if( factory == null ){
@@ -393,11 +392,7 @@ public class CommonDockStationFactory implements DockFactory<CommonDockStation<?
 		else{
 			id = null;
 		}
-		
-		boolean root = in.readBoolean();
-		
-		String factoryId = in.readUTF();
-		
+
 		int length = in.readInt();
 		byte[] content = new byte[length];
 		int offset = 0;
@@ -408,7 +403,9 @@ public class CommonDockStationFactory implements DockFactory<CommonDockStation<?
 			}
 			offset += delta;
 		}
-		
+
+		boolean root = in.readBoolean();
+		String factoryId = in.readUTF();
 		DockFactory<DockElement, ?, Object> factory = (DockFactory<DockElement, ?, Object>)control.intern().getDockFactory( factoryId );
 		if( factory == null ){
 			return new CommonDockStationLayout( id, root, factoryId, content );

--- a/docking-frames-common/src/bibliothek/gui/dock/common/layout/FullLockConflictResolver.java
+++ b/docking-frames-common/src/bibliothek/gui/dock/common/layout/FullLockConflictResolver.java
@@ -95,11 +95,11 @@ public class FullLockConflictResolver extends DefaultConflictResolver<RequestDim
             ResizeNode<RequestDimension> node = (ResizeNode<RequestDimension>)element;
 
             ResizeRequest leftRequest = node.getLeft().getRequest();
-            ResizeRequest rightRequest = node.getRight().getRequest();
 
             if( leftRequest == null || leftRequest.getFractionWidth() == -1 )
                 return false;
 
+            ResizeRequest rightRequest = node.getRight().getRequest();
             if( rightRequest == null || rightRequest.getFractionWidth() == -1 )
                 return false;
 
@@ -139,11 +139,11 @@ public class FullLockConflictResolver extends DefaultConflictResolver<RequestDim
             ResizeNode<RequestDimension> node = (ResizeNode<RequestDimension>)element;
 
             ResizeRequest leftRequest = node.getLeft().getRequest();
-            ResizeRequest rightRequest = node.getRight().getRequest();
 
             if( leftRequest == null || leftRequest.getFractionHeight() == -1 )
                 return false;
 
+            ResizeRequest rightRequest = node.getRight().getRequest();
             if( rightRequest == null || rightRequest.getFractionHeight() == -1 )
                 return false;
 

--- a/docking-frames-common/src/bibliothek/gui/dock/common/mode/station/CScreenDockStationHandle.java
+++ b/docking-frames-common/src/bibliothek/gui/dock/common/mode/station/CScreenDockStationHandle.java
@@ -378,12 +378,13 @@ public class CScreenDockStationHandle {
 					station.setFullscreen( dockable, false );
 				}
 				else{
-					Dockable child = DockUtilities.getDirectChild( station, dockable );
-					ScreenDockProperty location = station.getLocation( child, dockable );
-					
+
 					if( !parent.canDrag( dockable )){
 						throw new IllegalArgumentException( "cannot drag dockable from its current parent" );
 					}
+
+					Dockable child = DockUtilities.getDirectChild( station, dockable );
+					ScreenDockProperty location = station.getLocation( child, dockable );
 					location.setFullscreen( false );
 					if( !station.drop( dockable, location, true )){
 						throw new IllegalStateException( "could not drop dockable on this station" );

--- a/docking-frames-core/src/bibliothek/extension/gui/dock/station/SplitCombiner.java
+++ b/docking-frames-core/src/bibliothek/extension/gui/dock/station/SplitCombiner.java
@@ -139,18 +139,18 @@ public class SplitCombiner extends BasicCombiner{
 
 	public Dockable combine( CombinerSource source, CombinerTarget target ){
 		if( target instanceof Target ){
-			DockStation parent = source.getParent();
-			PlaceholderMap placeholders = source.getPlaceholders();
-			
+
 			SplitDockStation split = new SplitDockStation(){
 				@Override
 				protected ListeningDockAction createFullScreenAction(){
 					return null;
 				}
 			};
+			DockStation parent = source.getParent();
 			split.setController( parent.getController() );
 			split.updateTheme();
-			
+
+			PlaceholderMap placeholders = source.getPlaceholders();
 	        if( placeholders != null ){
 	        	split.setPlaceholders( placeholders );
 	        }

--- a/docking-frames-core/src/bibliothek/gui/DockFrontend.java
+++ b/docking-frames-core/src/bibliothek/gui/DockFrontend.java
@@ -1423,7 +1423,6 @@ public class DockFrontend {
                     }
                     else{
                         String root = info.getRoot();
-                        DockableProperty location = info.getLocation();
 
                         DockStation station;
                         if( root == null )
@@ -1437,6 +1436,7 @@ public class DockFrontend {
                                 throw new IllegalStateException( "Can't find the default station" );
                         }
 
+                        DockableProperty location = info.getLocation();
                         if( location == null )
                             getDefaultStation().drop( dockable );
                         else{

--- a/docking-frames-core/src/bibliothek/gui/dock/FlapDockStation.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/FlapDockStation.java
@@ -1462,22 +1462,18 @@ public class FlapDockStation extends AbstractDockableStation {
     }
     
     public StationDropOperation prepareDrop( StationDropItem item ){
-    	int mouseX = item.getMouseX();
-    	int mouseY = item.getMouseY();
     	Dockable dockable = item.getDockable();
-    	
-    	boolean move = dockable.getDockParent() == this;
-    	
+
     	if( SwingUtilities.isDescendingFrom( getComponent(), dockable.getComponent() )){
     		return null;
     	}
-        
+
+        int mouseX = item.getMouseX();
+        int mouseY = item.getMouseY();
         Point mouse = new Point( mouseX, mouseY );
         SwingUtilities.convertPointFromScreen( mouse, buttonPane );
         FlapDropInfo dropInfo = null;
-        
-        DockAcceptance acceptance = getController().getAcceptance();
-        
+
         // if mouse over window title: force combination
         if( window != null && window.isWindowVisible() ){
             DockTitle title = window.getDockTitle();
@@ -1510,7 +1506,8 @@ public class FlapDockStation extends AbstractDockableStation {
         
         if( dropInfo != null && dockable == getFrontDockable() )
             return null;
-        
+
+        DockAcceptance acceptance = getController().getAcceptance();
         if( dropInfo == null ){
             if( dockable.accept( this ) &&
                 accept( dockable ) &&
@@ -1548,7 +1545,8 @@ public class FlapDockStation extends AbstractDockableStation {
         if( dropInfo == null ){
         	return null;
         }
-        
+
+        boolean move = dockable.getDockParent() == this;
         return new FlapDropOperation( dropInfo, move );
         
     }
@@ -2052,9 +2050,7 @@ public class FlapDockStation extends AbstractDockableStation {
 	        
 	        if( append.getDockParent() != null )
 	            append.getDockParent().drag( append );
-	        
-	        boolean hold = isHold( child );
-	        
+
 	        int listIndex = handles.levelToBase( index, Level.DOCKABLE );
 	        DockablePlaceholderList<DockableHandle>.Item oldItem = handles.list().get( listIndex );
 	        final PlaceholderMap placeholders = oldItem.getPlaceholderMap();
@@ -2089,7 +2085,8 @@ public class FlapDockStation extends AbstractDockableStation {
 	        listIndex = handles.levelToBase( index, Level.DOCKABLE );
 	        DockablePlaceholderList<DockableHandle>.Item newItem = handles.list().get( listIndex );
 	        newItem.setPlaceholderSet( newItem.getPlaceholderSet() );
-	        
+
+            boolean hold = isHold( child );
 	        setHold( combination, hold );
 	        return true;
     	}
@@ -2443,11 +2440,10 @@ public class FlapDockStation extends AbstractDockableStation {
                     return;
                 
                 DockController controller = event.getController();
-                Dockable dockable = event.getNewFocusOwner();
-                
                 if( controller.isFocused( FlapDockStation.this ))
                     return;
-                
+
+                Dockable dockable = event.getNewFocusOwner();
                 if( dockable == null || !DockUtilities.isAncestor( FlapDockStation.this, dockable ) ){
                 	setFrontDockable( null );
                 }

--- a/docking-frames-core/src/bibliothek/gui/dock/ScreenDockStation.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/ScreenDockStation.java
@@ -1684,14 +1684,14 @@ public class ScreenDockStation extends AbstractDockStation {
     private void combine( CombinerSource source, CombinerTarget target, DockableProperty property ){
     	DockUtilities.checkLayoutLocked();
     	Dockable lower = source.getOld();
-    	Dockable upper = source.getNew();
-    	
+
     	int index = indexOf( lower );
     	if( index < 0 ){
     		throw new IllegalArgumentException( "old is not child of this station" );
     	}
     	
         ScreenDockWindowHandle window = getWindowHandle( index );
+		Dockable upper = source.getNew();
         removeDockable( upper );
         
         index = indexOf( lower );

--- a/docking-frames-core/src/bibliothek/gui/dock/SplitDockStation.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/SplitDockStation.java
@@ -2284,8 +2284,7 @@ public class SplitDockStation extends SecureContainer implements Dockable, DockS
 		try{
 			access.arm();
 			DockUtilities.checkLayoutLocked();
-	
-			DockableProperty successor = property.getSuccessor();
+
 			if( dockable.getDockParent() == this ) {
 				setFullScreen(dockable);
 				return true;
@@ -2297,6 +2296,7 @@ public class SplitDockStation extends SecureContainer implements Dockable, DockS
 			}
 			
 			DockStation currentFullScreenStation = currentFullScreen.asDockStation();
+			DockableProperty successor = property.getSuccessor();
 			if( currentFullScreenStation != null ){
 				if( successor != null ){
 					if( currentFullScreenStation.drop( dockable, successor )){

--- a/docking-frames-core/src/bibliothek/gui/dock/StackDockStation.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/StackDockStation.java
@@ -869,12 +869,12 @@ public class StackDockStation extends AbstractDockableStation implements StackDo
     	return dockables.toMap( new PlaceholderListItemAdapter<Dockable, StationChildHandle>() {
     		@Override
     		public ConvertedPlaceholderListItem convert( int index, StationChildHandle dockable ){
-    			ConvertedPlaceholderListItem item = new ConvertedPlaceholderListItem();
     			Integer id = children.get( dockable.getDockable() );
     			if( id == null ){
     				return null;
     			}
-    			
+
+                ConvertedPlaceholderListItem item = new ConvertedPlaceholderListItem();
     			item.putInt( "id", id );
     			item.putInt( "index", index );
     			if( strategy != null ){
@@ -1410,7 +1410,6 @@ public class StackDockStation extends AbstractDockableStation implements StackDo
             panel.add( displayer.getComponent() );
         }
         else{
-        	int selectionIndex = index;
         	int oldSelectionIndex = 0;
         	
             if( size == 1 && !singleTabStackDockComponent() ){
@@ -1437,6 +1436,7 @@ public class StackDockStation extends AbstractDockableStation implements StackDo
             }
             
             DockableDisplayer displayer = handle.getDisplayer();
+            int selectionIndex = index;
             insertTab( displayer, index );
             
             if( isImmutableSelectedIndex() ){

--- a/docking-frames-core/src/bibliothek/gui/dock/control/focus/DefaultFocusStrategy.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/control/focus/DefaultFocusStrategy.java
@@ -100,14 +100,14 @@ public class DefaultFocusStrategy implements FocusStrategy{
 	
 	public Component getFocusComponent( FocusStrategyRequest request ){
 		Component mouseClicked = request.getMouseClicked();
-		Dockable dockable = request.getDockable();
-		
+
 		if( mouseClicked != null ){
 			if( (mouseClicked.isFocusable() && !excluded( mouseClicked, request )) || focusable( mouseClicked, request )){
 				return mouseClicked;
 			}
 		}
-		
+
+		Dockable dockable = request.getDockable();
 		Tracker tracker = trackers.get( dockable.getComponent() );
 		if( tracker == null ){
 			return null;

--- a/docking-frames-core/src/bibliothek/gui/dock/control/relocator/DefaultDockRelocator.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/control/relocator/DefaultDockRelocator.java
@@ -693,8 +693,6 @@ public class DefaultDockRelocator extends AbstractDockRelocator{
                 mouse.x, mouse.y,
                 mouse.x - pressPointLocal.x, mouse.y - pressPointLocal.y,
                 dockable );
-        
-        boolean drop = false;
 
         Dockable[] implicit = next == null ? new Dockable[]{} : next.getImplicit( dockable );
         boolean move = next != null && next.getOperation().isMove();
@@ -710,7 +708,8 @@ public class DefaultDockRelocator extends AbstractDockRelocator{
     	else if( event.isIgnored() ){
     		return Reaction.CONTINUE;
     	}
-        
+
+		boolean drop = false;
         if( next != null ){
             drop = next != null && event.isDropping();
         }

--- a/docking-frames-core/src/bibliothek/gui/dock/control/relocator/MergeOperation.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/control/relocator/MergeOperation.java
@@ -87,7 +87,6 @@ public class MergeOperation implements RelocateOperation{
 	}
 	
 	public boolean execute( Dockable selection, VetoableDockRelocatorListener listener ){
-		DockStation child = selection.asDockStation();
 		DockStation parent = selection.getDockParent();
 
 		Dockable[] children = getImplicit( selection );
@@ -100,7 +99,8 @@ public class MergeOperation implements RelocateOperation{
 				return false;
 			}
 		}
-		
+
+		DockStation child = selection.asDockStation();
 		merger.merge( operation, station, child );
 		
 		parent = selection.getDockParent();

--- a/docking-frames-core/src/bibliothek/gui/dock/displayer/DisplayerFocusTraversalPolicy.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/displayer/DisplayerFocusTraversalPolicy.java
@@ -90,12 +90,12 @@ public class DisplayerFocusTraversalPolicy implements SimplifiedFocusTraversalPo
     }
 
     public Component getFirst( Container container ) {
-        DockTitle title = displayer.getTitle();
         Dockable dockable = displayer.getDockable();
         
         if( dockable != null )
             return dockable.getComponent();
-        
+
+        DockTitle title = displayer.getTitle();
         if( title != null )
             return title.getComponent();
         
@@ -104,11 +104,11 @@ public class DisplayerFocusTraversalPolicy implements SimplifiedFocusTraversalPo
 
     public Component getLast( Container container ) {
         DockTitle title = displayer.getTitle();
-        Dockable dockable = displayer.getDockable();
-        
+
         if( title != null )
             return title.getComponent();
-        
+
+        Dockable dockable = displayer.getDockable();
         if( dockable != null )
             return dockable.getComponent();
         

--- a/docking-frames-core/src/bibliothek/gui/dock/layout/DockSituation.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/layout/DockSituation.java
@@ -548,10 +548,6 @@ public class DockSituation {
 	    		entryPlaceholder = new Path( in.readUTF() );
 	   		}
     	}
-    	
-        byte[] entry = readBuffer( in );
-
-        DockLayoutInfo info = readEntry( entry, entryPlaceholder );
 
         List<DockLayout<?>> adjacentLayouts = null;
         if( Version.VERSION_1_0_7.compareTo( version ) <= 0 ){
@@ -606,6 +602,8 @@ public class DockSituation {
             children.add( readCompositionStream( in, version ) );
         }
 
+        byte[] entry = readBuffer( in );
+        DockLayoutInfo info = readEntry( entry, entryPlaceholder );
         // result
         return new DockLayoutComposition( info, adjacentLayouts, children, ignore );
     }

--- a/docking-frames-core/src/bibliothek/gui/dock/layout/PredefinedDockSituation.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/layout/PredefinedDockSituation.java
@@ -821,8 +821,7 @@ public class PredefinedDockSituation extends DockSituation {
             version.checkCurrent();
 
             boolean version7 = Version.VERSION_1_0_7.compareTo( version ) <= 0;
-            
-            String preloaded = in.readUTF();
+
             boolean nullValue = false;
             if( version7 ){
                 nullValue = !in.readBoolean();
@@ -871,6 +870,7 @@ public class PredefinedDockSituation extends DockSituation {
             if( info == null )
                 return null;
 
+            String preloaded = in.readUTF();
             return new PredefinedLayout( preloaded, info );
         }
 

--- a/docking-frames-core/src/bibliothek/gui/dock/layout/PropertyTransformer.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/layout/PropertyTransformer.java
@@ -158,8 +158,6 @@ public class PropertyTransformer {
 			if (factory == null)
 				throw new IOException( "Unknown factory-id: " + id );
 
-			DockableProperty temp = factory.createProperty();
-
 			int length = in.readInt();
 			byte[] data = new byte[length];
 			int index = 0;
@@ -171,6 +169,7 @@ public class PropertyTransformer {
 				index += read;
 			}
 
+			DockableProperty temp = factory.createProperty();
 			DataInputStream datas = new DataInputStream(
 					new ByteArrayInputStream( data ) );
 			temp.load( datas );

--- a/docking-frames-core/src/bibliothek/gui/dock/station/flap/ButtonPane.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/station/flap/ButtonPane.java
@@ -279,11 +279,11 @@ public class ButtonPane extends SecureContainer{
                 DockTitle title = station.getButton( i );
                 if( title != null ){
                     int tx = title.getComponent().getX();
-                    int tw = title.getComponent().getWidth();
-                    
+
                     if( x <= tx )
                         return i;
-                    
+
+                    int tw = title.getComponent().getWidth();
                     if( x <= tx + tw ){
                         if( x < tx + tw/2 )
                             return i;
@@ -298,11 +298,11 @@ public class ButtonPane extends SecureContainer{
                 DockTitle title = station.getButton( i );
                 if( title != null ){
                     int ty = title.getComponent().getY();
-                    int th = title.getComponent().getHeight();
                     
                     if( y <= ty )
                         return i;
-                    
+
+                    int th = title.getComponent().getHeight();
                     if( y <= ty + th ){
                         if( y < ty + th/2 )
                             return i;

--- a/docking-frames-core/src/bibliothek/gui/dock/station/split/DefaultSplitLayoutManager.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/station/split/DefaultSplitLayoutManager.java
@@ -177,7 +177,6 @@ public class DefaultSplitLayoutManager implements SplitLayoutManager{
     }
     
     public void calculateDivider( SplitDockStation station, PutInfo putInfo, Leaf origin, StationDropItem item ){
-        final double MINIMUM_ORIGINAL_SIZE = 0.25;
         
         SplitNode other = putInfo.getNode();
         if( other == null ){
@@ -215,7 +214,8 @@ public class DefaultSplitLayoutManager implements SplitLayoutManager{
                 size = putInfo.getOldSize();
             }
         }
-        
+
+        final double MINIMUM_ORIGINAL_SIZE = 0.25;
         double divider = 0.5;
         int dividerSize = station.getDividerSize();
         

--- a/docking-frames-core/src/bibliothek/gui/dock/station/split/Node.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/station/split/Node.java
@@ -694,12 +694,12 @@ public class Node extends VisibleSplitNode implements Divideable{
     			if( needToExpand( node ) ){
     				// split up this node
     				long leafId = getLeafId( property );
-    				long splitId = getSplitId( property, depth );
-    				
+
     				Leaf leaf = create( dockable, leafId );
     				if( leaf == null )
     					return false;
 
+					long splitId = getSplitId( property, depth );
     				split( property, depth, leaf, splitId );
     				leaf.setDockable( dockable, null );
     				return true;

--- a/docking-frames-core/src/bibliothek/gui/dock/station/split/SplitNode.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/station/split/SplitNode.java
@@ -847,12 +847,12 @@ public abstract class SplitNode{
      */
     protected Leaf create( Dockable dockable, long id ){
         SplitDockStation split = access.getOwner();
-        DockController controller = split.getController();
-        DockAcceptance acceptance = controller == null ? null : controller.getAcceptance();
-        
+
         if( !dockable.accept( split ) || !split.accept( dockable ))
             return null;
-        
+
+		DockController controller = split.getController();
+		DockAcceptance acceptance = controller == null ? null : controller.getAcceptance();
         if( acceptance != null ){
             if( !acceptance.accept( split, dockable ))
                 return null;
@@ -1039,12 +1039,12 @@ public abstract class SplitNode{
      * otherwise
      */
     public static boolean above( double x1, double y1, double x2, double y2, double x, double y ){
-        double a = y1 - y2;
         double b = x2 - x1;
         
         if( b == 0 )
             return false;
-        
+
+		double a = y1 - y2;
         double c = a*x1 + b*y1;
         double sy = (c - a*x) / b;
         

--- a/docking-frames-core/src/bibliothek/gui/dock/station/stack/tab/MenuLineLayoutPane.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/station/stack/tab/MenuLineLayoutPane.java
@@ -293,15 +293,15 @@ public class MenuLineLayoutPane extends AbstractTabLayoutManagerPane{
 	
 	private void listLayouts( List<MenuLineLayoutPossibility> list, Size infoSize, Size menuSize, Size tabSize ){
 		boolean tabMustBeMinimum = (infoSize != null && infoSize.isMinimum()) || (menuSize != null);
-		boolean tabMustBeSingle = menuSize != null && menuSize.isMinimum();
-		boolean infoMustBeMinimum = menuSize != null && menuSize.isMinimum();
-		
+
 		if( tabMustBeMinimum && !tabSize.isMinimum() )
 			return;
-		
+
+		boolean tabMustBeSingle = menuSize != null && menuSize.isMinimum();
 		if( tabMustBeSingle && tabs.getTabsCount( tabSize ) > 1 )
 			return;
-		
+
+		boolean infoMustBeMinimum = menuSize != null && menuSize.isMinimum();
 		if( infoMustBeMinimum && (infoSize != null && !infoSize.isMinimum()))
 			return;
 		

--- a/docking-frames-core/src/bibliothek/gui/dock/station/stack/tab/layouting/AbstractTabsLayoutBlock.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/station/stack/tab/layouting/AbstractTabsLayoutBlock.java
@@ -164,7 +164,6 @@ public abstract class AbstractTabsLayoutBlock implements TabsLayoutBlock{
 	 * is not a child of this blocks {@link TabPane} 
 	 */
 	public void insertTab( Tab tab ){
-		int[] locations = getOriginalTabLocations();
 		TabPane pane = getPane();
 		
 		Dockable[] dockables = pane.getDockables();
@@ -185,7 +184,8 @@ public abstract class AbstractTabsLayoutBlock implements TabsLayoutBlock{
 		int wrongSmaller = 0;
 		// number of indices to the left that are bigger
 		int wrongBigger = 0;
-		
+
+		int[] locations = getOriginalTabLocations();
 		for( int i = 0; i < locations.length; i++ ){
 			if( locations[i] < index ){
 				wrongSmaller++;

--- a/docking-frames-core/src/bibliothek/gui/dock/themes/basic/DisplayerContentPane.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/themes/basic/DisplayerContentPane.java
@@ -188,16 +188,15 @@ public class DisplayerContentPane extends ConfiguredBackgroundPanel{
         Insets insets = getInsets();
         if( insets == null )
             insets = new Insets( 0,0,0,0 );
-        
-        int x = insets.left;
-        int y = insets.top;
-        int width = getWidth() - insets.left - insets.right;
-        int height = getHeight() - insets.top - insets.bottom;
-        
+
         if( title == null && dockable == null )
             return;
-        
-        width = Math.max( 0, width );
+
+		int x = insets.left;
+		int y = insets.top;
+		int width = getWidth() - insets.left - insets.right;
+		int height = getHeight() - insets.top - insets.bottom;
+		width = Math.max( 0, width );
         height = Math.max( 0, height );
         
         if( title == null )

--- a/docking-frames-core/src/bibliothek/gui/dock/util/DockUtilities.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/util/DockUtilities.java
@@ -448,9 +448,7 @@ public class DockUtilities {
         
         if( newChild == null )
             throw new NullPointerException( "child must not be null" );
-        
-        DockStation oldParent = newChild.getDockParent();
-            
+
         // check no self reference
         if( newChild == newParent )
             throw new IllegalArgumentException( "child and parent are the same" );
@@ -459,7 +457,8 @@ public class DockUtilities {
         if( isAncestor( newChild, newParent )){
             throw new IllegalArgumentException( "can't create a cycle" );
         }
-        
+
+        DockStation oldParent = newChild.getDockParent();
         // remove old parent
         if( oldParent != null ){
             if( oldParent != newParent && !oldParent.canDrag( newChild ))
@@ -485,9 +484,7 @@ public class DockUtilities {
         
         if( newChild == null )
             throw new NullPointerException( "child must not be null" );
-        
-        PerspectiveStation oldParent = newChild.getParent();
-            
+
         // check no self reference
         if( newChild == newParent )
             throw new IllegalArgumentException( "child and parent are the same" );
@@ -496,7 +493,8 @@ public class DockUtilities {
         if( isAncestor( newChild, newParent )){
             throw new IllegalArgumentException( "can't create a cycle" );
         }
-        
+
+        PerspectiveStation oldParent = newChild.getParent();
         // remove old parent
         if( oldParent != null && oldParent != newParent ){
         	oldParent.remove( newChild );

--- a/docking-frames-core/src/bibliothek/gui/dock/util/swing/OrientedLabel.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/util/swing/OrientedLabel.java
@@ -316,13 +316,13 @@ public class OrientedLabel extends ConfiguredBackgroundPanel{
     
     @Override
     public Dimension getPreferredSize() {
-    	Dimension size = label.getPreferredSize();
     	String text = getText();
 
     	if( (text == null || text.length() == 0) && icon != null ){
     		return new Dimension( icon.getIconWidth() + 2*iconOffset, icon.getIconHeight()+2*iconOffset );	
     	}
-    	
+
+        Dimension size = label.getPreferredSize();
         if( isHorizontal() ){
         	if( icon == null )
         		return new Dimension( size.width+5, size.height );

--- a/docking-frames-ext-toolbar/src/bibliothek/gui/dock/ToolbarDockStation.java
+++ b/docking-frames-ext-toolbar/src/bibliothek/gui/dock/ToolbarDockStation.java
@@ -383,12 +383,12 @@ public class ToolbarDockStation extends AbstractToolbarDockStation {
 	@Override
 	public StationDropOperation prepareDrop( StationDropItem item ){
 		// System.out.println(this.toString() + "## prepareDrop(...) ##");
-		final DockController controller = getController();
 
 		if( getExpandedState() == ExpandedState.EXPANDED ) {
 			return null;
 		}
 
+		final DockController controller = getController();
 		Dockable dockable = item.getDockable();
 		// check if the dockable and the station accept each other
 		if( this.accept( dockable ) && dockable.accept( this ) ) {
@@ -1220,7 +1220,6 @@ public class ToolbarDockStation extends AbstractToolbarDockStation {
 	}
 	
 	public void aside( AsideRequest request ){
-		int index = -1;
 		int resultIndex = -1;
 		
 		if( getExpandedState() == ExpandedState.EXPANDED && getDockableCount() == 1 ){
@@ -1234,7 +1233,8 @@ public class ToolbarDockStation extends AbstractToolbarDockStation {
 				resultIndex = ((StackDockProperty) answerLocation).getIndex();
 			}
 		}
-		
+
+		int index = -1;
 		DockableProperty location = request.getLocation();
 		Path newPlaceholder = request.getPlaceholder();
 		if( location instanceof ToolbarProperty ){

--- a/docking-frames-ext-toolbar/src/bibliothek/gui/dock/ToolbarGroupDockStation.java
+++ b/docking-frames-ext-toolbar/src/bibliothek/gui/dock/ToolbarGroupDockStation.java
@@ -642,7 +642,6 @@ public class ToolbarGroupDockStation extends AbstractToolbarDockStation {
 	@Override
 	public StationDropOperation prepareDrop( StationDropItem item ){
 		// System.out.println(this.toString() + "## prepareDrop(...) ##");
-		final DockController controller = getController();
 
 		if( getExpandedState() == ExpandedState.EXPANDED ) {
 			return null;
@@ -650,6 +649,7 @@ public class ToolbarGroupDockStation extends AbstractToolbarDockStation {
 
 		Dockable dockable = item.getDockable();
 
+		final DockController controller = getController();
 		// check if the dockable and the station accept each other
 		if( this.accept( dockable ) && dockable.accept( this ) ) {
 			// check if controller exists and if the controller accepts that

--- a/docking-frames-ext-toolbar/src/bibliothek/gui/dock/station/toolbar/DefaultToolbarContainerConverter.java
+++ b/docking-frames-ext-toolbar/src/bibliothek/gui/dock/station/toolbar/DefaultToolbarContainerConverter.java
@@ -81,12 +81,12 @@ public class DefaultToolbarContainerConverter implements ToolbarContainerConvert
 			public ConvertedPlaceholderListItem convert( int index, StationChildHandle handle ){
 				final Dockable dockable = handle.getDockable();
 
-				final ConvertedPlaceholderListItem item = new ConvertedPlaceholderListItem();
 				final Integer id = children.get( dockable );
 				if( id == null ) {
 					return null;
 				}
 
+				final ConvertedPlaceholderListItem item = new ConvertedPlaceholderListItem();
 				item.putInt( "id", id );
 				item.putInt( "index", index );
 				if( strategy != null ) {
@@ -105,12 +105,12 @@ public class DefaultToolbarContainerConverter implements ToolbarContainerConvert
 		return list.toMap( new PlaceholderListItemAdapter<PerspectiveDockable, PerspectiveDockable>(){
 			@Override
 			public ConvertedPlaceholderListItem convert( int index, PerspectiveDockable dockable ){
-				final ConvertedPlaceholderListItem item = new ConvertedPlaceholderListItem();
 				final Integer id = children.get( dockable );
 				if( id == null ) {
 					return null;
 				}
 
+				final ConvertedPlaceholderListItem item = new ConvertedPlaceholderListItem();
 				item.putInt( "id", id );
 				item.putInt( "index", index );
 				Path placeholder = dockable.getPlaceholder();

--- a/docking-frames-ext-toolbar/src/bibliothek/gui/dock/station/toolbar/ToolbarContainerDropInfo.java
+++ b/docking-frames-ext-toolbar/src/bibliothek/gui/dock/station/toolbar/ToolbarContainerDropInfo.java
@@ -304,8 +304,6 @@ public abstract class ToolbarContainerDropInfo implements StationDropOperation{
 		final Point coordDockableDragged = getItem().getComponent()
 				.getLocation();
 		if (getDockableBeneathMouse() != null){
-			final Point coordDockableBeneathMouse = getDockableBeneathMouse()
-					.getComponent().getLocation();
 			// The dockable is now in the frame of reference of the dockable
 			// beneath mouse
 			SwingUtilities.convertPointFromScreen(coordDockableDragged,
@@ -316,6 +314,8 @@ public abstract class ToolbarContainerDropInfo implements StationDropOperation{
 			if (getItem() == getDockableBeneathMouse()){
 				return Position.CENTER;
 			} else{
+				final Point coordDockableBeneathMouse = getDockableBeneathMouse()
+						.getComponent().getLocation();
 				switch (stationHost.getOrientation()) {
 				case VERTICAL:
 					if (coordDockableDragged.getY() <= coordDockableBeneathMouse

--- a/docking-frames-ext-toolbar/src/bibliothek/gui/dock/station/toolbar/group/ExpandToolbarGroupActions.java
+++ b/docking-frames-ext-toolbar/src/bibliothek/gui/dock/station/toolbar/group/ExpandToolbarGroupActions.java
@@ -187,7 +187,6 @@ public abstract class ExpandToolbarGroupActions<P> extends AbstractToolbarGroupA
 		 * @param action how to modify the state
 		 */
 		public void performAction( Action action ){
-			boolean[] canPerform = getEnabledStates();
 			ExpandedState current = getState();
 			ExpandedState next;
 			
@@ -207,7 +206,8 @@ public abstract class ExpandToolbarGroupActions<P> extends AbstractToolbarGroupA
 				default:
 					throw new IllegalStateException( "never happens" );
 			}
-			
+
+			boolean[] canPerform = getEnabledStates();
 			int attempts = canPerform.length;
 			while( attempts > 0 && current != next && !canPerform[ next.ordinal() ]){
 				attempts--;

--- a/docking-frames-ext-toolbar/src/bibliothek/gui/dock/station/toolbar/layout/PlaceholderToolbarGrid.java
+++ b/docking-frames-ext-toolbar/src/bibliothek/gui/dock/station/toolbar/layout/PlaceholderToolbarGrid.java
@@ -305,7 +305,6 @@ public abstract class PlaceholderToolbarGrid<D, S, P extends PlaceholderListItem
 	public void move( int sourceColumn, int sourceLine, int destinationColumn, int destinationLine, Level destinationLevel ){
 		PlaceholderList<D, S, P> source = columns.dockables().get( sourceColumn ).getList();
 		final Filter<P> sourceList = source.dockables();
-		int destinationColumnIndex = -1;
 		
 		if( destinationColumn == columns.size( destinationLevel ) ) {
 			destinationColumn = columns.size( Level.BASE );
@@ -322,8 +321,7 @@ public abstract class PlaceholderToolbarGrid<D, S, P extends PlaceholderListItem
 			throw new IllegalArgumentException( "destinationColumn out of bounds: " + destinationColumn );
 		}
 
-		final P value = sourceList.get( sourceLine );
-
+		int destinationColumnIndex = -1;
 		PlaceholderList<D, S, P> list;
 		if( (destinationColumn == -1) || (destinationColumn == columns.list().size()) ) {
 			list = createColumn();
@@ -362,7 +360,8 @@ public abstract class PlaceholderToolbarGrid<D, S, P extends PlaceholderListItem
 		}
 
 		P moved = sourceList.get( sourceLine );
-		
+
+		final P value = sourceList.get( sourceLine );
 		list.dockables().move( sourceList, sourceLine, destinationLine );
 		ensureRemoved( list, value );
 		
@@ -1200,12 +1199,12 @@ public abstract class PlaceholderToolbarGrid<D, S, P extends PlaceholderListItem
 			columns.read( map, new PlaceholderListItemAdapter<GridPlaceholderList.ColumnItem<D, S, P>, GridPlaceholderList.Column<D, S, P>>(){
 				@Override
 				public GridPlaceholderList.Column<D, S, P> convert( ConvertedPlaceholderListItem item ){
-					final PlaceholderList<D, S, P> list = createColumn();
 					final PlaceholderMap map = item.getPlaceholderMap();
 					if( map == null ) {
 						return null;
 					}
 
+					final PlaceholderList<D, S, P> list = createColumn();
 					list.read( map, columns.getConverter() );
 					return columns.createColumn( list );
 				}

--- a/docking-frames-ext-toolbar/src/bibliothek/gui/dock/wizard/WizardColumnModel.java
+++ b/docking-frames-ext-toolbar/src/bibliothek/gui/dock/wizard/WizardColumnModel.java
@@ -385,13 +385,14 @@ public class WizardColumnModel {
 		}
 		else if( node instanceof Node ){
 			Node n = (Node)node;
-			
-			int left = applyPersistentSizes( n.getLeft(), column, map );
+
 			int right = applyPersistentSizes( n.getRight(), column, map );
 			
 			if( n.getLeft() == null || !n.getLeft().isVisible() ){
 				return right;
 			}
+
+			int left = applyPersistentSizes( n.getLeft(), column, map );
 			if( n.getRight() == null || !n.getRight().isVisible() ){
 				return left;
 			}

--- a/docking-frames-ext-toolbar/src/bibliothek/gui/dock/wizard/WizardNodeMap.java
+++ b/docking-frames-ext-toolbar/src/bibliothek/gui/dock/wizard/WizardNodeMap.java
@@ -615,13 +615,13 @@ public abstract class WizardNodeMap {
 		 * @return the new column, can be <code>null</code>
 		 */
 		public PersistentColumn toPersistentColumn(){
-			int size;
-			int preferred;
 			Map<Dockable, PersistentCell> leafs = getLeafs();
 			if( leafs.size() == 0 ){
 				return null;
 			}
-			
+
+			int size;
+			int preferred;
 			if( side().getHeaderOrientation() == Orientation.HORIZONTAL ){
 				size = root.getSize().width;
 				preferred = getPreferredSize().width;

--- a/docking-frames-ext-toolbar/src/bibliothek/gui/dock/wizard/WizardSplitDockStationFactory.java
+++ b/docking-frames-ext-toolbar/src/bibliothek/gui/dock/wizard/WizardSplitDockStationFactory.java
@@ -148,7 +148,6 @@ public class WizardSplitDockStationFactory extends SplitDockStationFactory{
 	
 	@Override
 	public SplitDockStationLayout read( DataInputStream in, PlaceholderStrategy placeholders ) throws IOException{
-		SplitDockStationLayout layout = super.read( in, placeholders );
 		Version version = Version.read( in );
 		if( !version.equals( Version.VERSION_1_1_1 )){
 			throw new IOException( "trying to read a format from the future: " + version );
@@ -166,6 +165,7 @@ public class WizardSplitDockStationFactory extends SplitDockStationFactory{
 			}
 			columns[i] = new Column( size, keys, sizes );
 		}
+		SplitDockStationLayout layout = super.read( in, placeholders );
 		((WizardSplitDockStationLayout)layout).setColumns( columns );
 		return layout;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1941 - Variables should not be declared before they are relevant

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1941

Please let me know if you have any questions.

M-Ezzat