### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/docking-frames-common/src/bibliothek/gui/dock/common/intern/CListenerCollection.java
+++ b/docking-frames-common/src/bibliothek/gui/dock/common/intern/CListenerCollection.java
@@ -280,7 +280,7 @@ public class CListenerCollection {
      * @return <code>true</code> if there is at least one listener
      */
     public boolean hasCDockableLocationListeners(){
-    	return locationListeners.size() > 0;
+    	return !locationListeners.isEmpty();
     }
     
     /**

--- a/docking-frames-common/src/bibliothek/gui/dock/common/perspective/CPerspective.java
+++ b/docking-frames-common/src/bibliothek/gui/dock/common/perspective/CPerspective.java
@@ -352,7 +352,7 @@ public class CPerspective {
 		}
 		
 		public PerspectiveElement next(){
-			while( stack.size() > 0 ){
+			while( !stack.isEmpty() ){
 				ElementFrame top = stack.peek();
 				if( top.offset < top.items.length ){
 					PerspectiveElement result = top.items[top.offset++];

--- a/docking-frames-common/src/bibliothek/gui/dock/facile/mode/LocationModeManager.java
+++ b/docking-frames-common/src/bibliothek/gui/dock/facile/mode/LocationModeManager.java
@@ -696,7 +696,7 @@ public class LocationModeManager<M extends LocationMode> extends ModeManager<Loc
 		
 		@Override
 		public void registerUnstalled( DockController controller ){
-			while( pendingRefreshs.size() > 0 && !controller.getRegister().isStalled() ){
+			while( !pendingRefreshs.isEmpty() && !controller.getRegister().isStalled() ){
 				Iterator<Dockable> iter = pendingRefreshs.iterator();
 				Dockable next = iter.next();
 				iter.remove();

--- a/docking-frames-core/src/bibliothek/extension/gui/dock/preference/AbstractPreference.java
+++ b/docking-frames-core/src/bibliothek/extension/gui/dock/preference/AbstractPreference.java
@@ -55,7 +55,7 @@ public abstract class AbstractPreference<V> implements Preference<V>{
      * @return <code>true</code> if there are any listeners
      */
     protected boolean hasListeners(){
-    	return listeners.size() > 0;
+    	return !listeners.isEmpty();
     }
     
     /**

--- a/docking-frames-core/src/bibliothek/extension/gui/dock/preference/PreferenceTreeModel.java
+++ b/docking-frames-core/src/bibliothek/extension/gui/dock/preference/PreferenceTreeModel.java
@@ -89,7 +89,7 @@ public class PreferenceTreeModel extends AbstractPreferenceModel implements Tree
 
     @Override
     protected boolean hasListeners(){
-    	return super.hasListeners() || treeListeners.size() > 0;
+    	return super.hasListeners() || !treeListeners.isEmpty();
     }
     
     public void addTreeModelListener( TreeModelListener l ) {

--- a/docking-frames-core/src/bibliothek/extension/gui/dock/preference/preferences/choice/DefaultChoice.java
+++ b/docking-frames-core/src/bibliothek/extension/gui/dock/preference/preferences/choice/DefaultChoice.java
@@ -336,7 +336,7 @@ public class DefaultChoice<V> implements Choice {
 			if( isNullEntryAllowed() )
 				return null;
 			
-			if( list.size() > 0 )
+			if( !list.isEmpty() )
 				return list.get( 0 ).getEntryId();
 			
 			return null;

--- a/docking-frames-core/src/bibliothek/gui/dock/SplitDockStation.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/SplitDockStation.java
@@ -1495,7 +1495,7 @@ public class SplitDockStation extends SecureContainer implements Dockable, DockS
 		if( isFullScreen() )
 			return getFullScreen();
 
-		if( frontDockable == null && dockables.size() > 0 )
+		if( frontDockable == null && !dockables.isEmpty() )
 			frontDockable = dockables.get(0).getDockable();
 
 		return frontDockable;
@@ -1610,7 +1610,7 @@ public class SplitDockStation extends SecureContainer implements Dockable, DockS
 	 * fullscreen (if it is not already fullscreen).
 	 */
 	public void setNextFullScreen(){
-		if( dockables.size() > 0 ) {
+		if( !dockables.isEmpty() ) {
 			if( fullScreenDockable == null )
 				setFullScreen(getDockable(0));
 			else {
@@ -3465,7 +3465,7 @@ public class SplitDockStation extends SecureContainer implements Dockable, DockS
 				}
 				repositioned.clear();
 				
-				if( dockables.size() > 0 ){
+				if( !dockables.isEmpty() ){
 					dockStationListeners.fireDockablesRepositioned( dockables.toArray( new Dockable[ dockables.size() ] ) );
 				}
 				

--- a/docking-frames-core/src/bibliothek/gui/dock/action/AbstractDockActionSource.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/action/AbstractDockActionSource.java
@@ -55,7 +55,7 @@ public abstract class AbstractDockActionSource implements DockActionSource {
      * @return whether at least one listener is registered
      */
     public boolean hasListeners(){
-    	return listeners.size() > 0;
+    	return !listeners.isEmpty();
     }
     
     /**

--- a/docking-frames-core/src/bibliothek/gui/dock/dockable/DockableStateListenerManager.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/dockable/DockableStateListenerManager.java
@@ -198,7 +198,7 @@ public class DockableStateListenerManager {
 	 * @return whether there is at least one listener
 	 */
 	protected boolean hasListeners(){
-		return listeners.size() > 0;
+		return !listeners.isEmpty();
 	}
 
 	/**
@@ -224,7 +224,7 @@ public class DockableStateListenerManager {
 	 */
 	private void fireNow(){
 		if( current != 0 ) {
-			if( listeners.size() > 0 ) {
+			if( !listeners.isEmpty() ) {
 				DockableStateEvent event = new DockableStateEvent( dockable, current );
 				current = 0;
 				for( DockableStateListener listener : listeners.toArray( new DockableStateListener[listeners.size()] ) ) {

--- a/docking-frames-core/src/bibliothek/gui/dock/frontend/VetoManager.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/frontend/VetoManager.java
@@ -180,7 +180,7 @@ public class VetoManager {
      * if not.
      */
     protected boolean fireAllHiding( Dockable dockable, final boolean cancelable ){
-        if( vetoableListeners.size() == 0 )
+        if( vetoableListeners.isEmpty() )
             return false;
         
         List<Dockable> list = DockUtilities.listDockables( dockable, true );
@@ -197,7 +197,7 @@ public class VetoManager {
      * if not.
      */
     protected boolean fireAllHiding( Collection<Dockable> dockables, final boolean cancelable ){
-        if( vetoableListeners.size() == 0 )
+        if( vetoableListeners.isEmpty() )
             return false;
         
         if( dockables.isEmpty() )
@@ -261,7 +261,7 @@ public class VetoManager {
      * if the operation can continue
      */
     protected boolean fireAllShowing( Dockable dockable, final boolean cancelable ){
-        if( vetoableListeners.size() == 0 )
+        if( vetoableListeners.isEmpty() )
             return false;
         
         return fireAllShowing( DockUtilities.listDockables( dockable, true ), cancelable );
@@ -277,7 +277,7 @@ public class VetoManager {
      * if the operation can continue
      */
     protected boolean fireAllShowing( Collection<Dockable> dockables, final boolean cancelable ){
-        if( vetoableListeners.size() == 0 )
+        if( vetoableListeners.isEmpty() )
             return false;
 
         if( dockables.isEmpty() )
@@ -299,7 +299,7 @@ public class VetoManager {
      * @param expected whether the event is expected or not
      */
     protected void fireAllShown( Dockable dockable, final boolean expected ){
-        if( vetoableListeners.size() == 0 )
+        if( vetoableListeners.isEmpty() )
             return;
 
         List<Dockable> list = DockUtilities.listDockables( dockable, true );
@@ -313,7 +313,7 @@ public class VetoManager {
      * @param expected whether the event is expected or not
      */
     protected void fireAllShown( Collection<Dockable> dockables, final boolean expected ){
-        if( vetoableListeners.size() == 0 )
+        if( vetoableListeners.isEmpty() )
             return;
 
         if( !dockables.isEmpty() ){

--- a/docking-frames-core/src/bibliothek/gui/dock/layout/DockSituation.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/layout/DockSituation.java
@@ -1188,7 +1188,7 @@ public class DockSituation {
     	DockLayoutComposition composition = map.getRoot();
 
     	List<DockLayoutComposition> children = composition.getChildren();
-    	if( children == null || children.size() == 0 ){
+    	if( children == null || children.isEmpty() ){
     		return;
     	}
 

--- a/docking-frames-core/src/bibliothek/gui/dock/themes/DefaultThemeMeta.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/themes/DefaultThemeMeta.java
@@ -88,7 +88,7 @@ public class DefaultThemeMeta implements ThemeMeta {
 	 * @return <code>true</code> if there is at least one listener
 	 */
 	protected boolean hasListeners(){
-		return listeners.size() > 0;
+		return !listeners.isEmpty();
 	}
 	
 	/**
@@ -141,7 +141,7 @@ public class DefaultThemeMeta implements ThemeMeta {
 		if( listener == null ){
 			throw new IllegalArgumentException( "listener must not be null" );
 		}
-		if( listeners.size() == 0 ){
+		if( listeners.isEmpty() ){
 			name.setController( controller );
 			description.setController( controller );
 		}
@@ -150,7 +150,7 @@ public class DefaultThemeMeta implements ThemeMeta {
 
 	public void removeListener( ThemeMetaListener listener ){
 		listeners.remove( listener );
-		if( listeners.size() == 0 ){
+		if( listeners.isEmpty() ){
 			name.setController( null );
 			description.setController( null );
 		}
@@ -166,14 +166,14 @@ public class DefaultThemeMeta implements ThemeMeta {
 	}
 
 	public String getDescription(){
-		if( listeners.size() == 0 ){
+		if( listeners.isEmpty() ){
 			description.update( controller.getTexts() );
 		}
 		return description.value();
 	}
 
 	public String getName(){
-		if( listeners.size() == 0 ){
+		if( listeners.isEmpty() ){
 			name.update( controller.getTexts() );
 		}
 		return name.value();

--- a/docking-frames-core/src/bibliothek/gui/dock/themes/basic/action/buttons/ButtonPanel.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/themes/basic/action/buttons/ButtonPanel.java
@@ -206,7 +206,7 @@ public class ButtonPanel extends JPanel{
      * @return whether at least one action is present
      */
     public boolean hasActions(){
-    	return actions.size() > 0;
+    	return !actions.isEmpty();
     }
     
     /**

--- a/docking-frames-core/src/bibliothek/gui/dock/themes/color/AbstractColorScheme.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/themes/color/AbstractColorScheme.java
@@ -106,7 +106,7 @@ public abstract class AbstractColorScheme implements ColorScheme{
      * @return <code>true</code> if there is at least one listener attached
      */
     protected boolean hasListeners(){
-    	return listeners.size() > 0;
+    	return !listeners.isEmpty();
     }
     
     /**
@@ -145,7 +145,7 @@ public abstract class AbstractColorScheme implements ColorScheme{
     }
     
     private boolean shouldListenUI(){
-    	return managers.size() > 0 || listeners.size() > 0;
+    	return !managers.isEmpty() || !listeners.isEmpty();
     }
     
     /**

--- a/docking-frames-core/src/bibliothek/gui/dock/util/AbstractWindowProvider.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/util/AbstractWindowProvider.java
@@ -70,7 +70,7 @@ public abstract class AbstractWindowProvider implements WindowProvider{
     protected void updateVisibility(){
     	Window current = searchWindow();
     	if( window != current ){
-    		if( listeners.size() > 0 ){
+    		if( !listeners.isEmpty() ){
 	    		if( window != null )
 	    			window.removeComponentListener( windowListener );
 	    		if( current != null )
@@ -121,14 +121,14 @@ public abstract class AbstractWindowProvider implements WindowProvider{
      * @return whether this provider is monitored
      */
     protected boolean hasListeners(){
-    	return listeners.size() > 0;
+    	return !listeners.isEmpty();
     }
     
     public void addWindowProviderListener( WindowProviderListener listener ) {
         if( listener == null )
             throw new IllegalArgumentException( "null is not allowed as listener" );
         
-        if( listeners.size() == 0 ){
+        if( listeners.isEmpty() ){
         	updateVisibility();
         	if( window != null ){
         		window.addComponentListener( windowListener );
@@ -142,7 +142,7 @@ public abstract class AbstractWindowProvider implements WindowProvider{
     public void removeWindowProviderListener( WindowProviderListener listener ) {
         listeners.remove( listener );
         
-        if( listeners.size() == 0 ){
+        if( listeners.isEmpty() ){
         	if( window != null ){
         		window.removeComponentListener( windowListener );
         	}

--- a/docking-frames-core/src/bibliothek/gui/dock/util/FocusedWindowProvider.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/util/FocusedWindowProvider.java
@@ -80,7 +80,7 @@ public class FocusedWindowProvider extends AbstractWindowProvider{
 		window.removeWindowFocusListener( listener );
 		if( current == window ){
 			current = null;
-			if( history.size() > 0 ){
+			if( !history.isEmpty() ){
 				current = history.get( history.size()-1 );
 			}
 			fireWindowChanged( current );

--- a/docking-frames-core/src/bibliothek/gui/dock/util/WindowProviderWrapper.java
+++ b/docking-frames-core/src/bibliothek/gui/dock/util/WindowProviderWrapper.java
@@ -55,14 +55,14 @@ public class WindowProviderWrapper implements WindowProvider{
     public void addWindowProviderListener( WindowProviderListener listener ) {
         int previous = listeners.size();
         listeners.add( listener );
-        if( previous == 0 && listeners.size() > 0 && delegate != null )
+        if( previous == 0 && !listeners.isEmpty() && delegate != null )
             delegate.addWindowProviderListener( this.listener );
     }
     
     public void removeWindowProviderListener( WindowProviderListener listener ) {
         int previous = listeners.size();
         listeners.remove( listener );
-        if( previous > 0 && listeners.size() == 0 && delegate != null )
+        if( previous > 0 && listeners.isEmpty() && delegate != null )
             delegate.removeWindowProviderListener( this.listener );
     }
     
@@ -99,7 +99,7 @@ public class WindowProviderWrapper implements WindowProvider{
      * @param delegate the new provider, can be <code>null</code>
      */
     public void setDelegate( WindowProvider delegate ) {
-        if( listeners.size() == 0 ){
+        if( listeners.isEmpty() ){
             this.delegate = delegate;
         }
         else{

--- a/docking-frames-ext-toolbar/src/bibliothek/gui/dock/ToolbarGroupDockStation.java
+++ b/docking-frames-ext-toolbar/src/bibliothek/gui/dock/ToolbarGroupDockStation.java
@@ -1066,7 +1066,7 @@ public class ToolbarGroupDockStation extends AbstractToolbarDockStation {
 			}
 		}
 
-		if( list.size() > 0 ) {
+		if( !list.isEmpty() ) {
 			listeners.fireDockablesRepositioned( list.toArray( new Dockable[list.size()] ) );
 		}
 	}

--- a/docking-frames-ext-toolbar/src/bibliothek/gui/dock/wizard/WizardNodeMap.java
+++ b/docking-frames-ext-toolbar/src/bibliothek/gui/dock/wizard/WizardNodeMap.java
@@ -506,7 +506,7 @@ public abstract class WizardNodeMap {
 					column.setSize( Math.max( source.getSize(), column.getPreferredSize() ));
 				}
 			}
-			else if( sources.size() > 0 ){
+			else if( !sources.isEmpty() ){
 				int max = 0;
 				for( PersistentColumn source : sources ){
 					max = Math.max( max, source.getSize() );


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat